### PR TITLE
Remove unused transformers

### DIFF
--- a/HFCTM-II-ORION/requirements.txt
+++ b/HFCTM-II-ORION/requirements.txt
@@ -8,4 +8,3 @@ networkx
 sympy
 matplotlib
 qiskit
-transformers

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ pytest -q
 The pinned `httpx` version has been tested with FastAPI's `TestClient` to ensure
 API routes load correctly.
 
+## Dependency Notes
+The repository previously listed Hugging Face's `transformers` library in
+`requirements.txt`, but no modules actually used it. The dependency has been
+removed to keep installation lightweight.
+
 ## Automation Scripts
 Scripts such as `commit_file.py` can automatically commit changes. To push to a
 remote repository these scripts require a `GITHUB_TOKEN` environment variable.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ networkx==3.2.1
 sympy==1.13.1
 matplotlib==3.8.2
 qiskit==0.45.0
-transformers==4.38.1
 pytest==8.0.0
 httpx==0.27.0
 stable-baselines3==2.2.1


### PR DESCRIPTION
## Summary
- strip the unused transformers dependency from `requirements.txt` files
- document the removal in the README

## Testing
- `PYTHONPATH=. pytest -q tests/test_models.py tests/test_recursive_ai.py tests/test_api.py`

------
https://chatgpt.com/codex/tasks/task_e_684123e8ca588333aa2afa6b661421a7