### PR TITLE
Add hardware accelerator configs and Aspen GPU profile

### DIFF
--- a/configs/ironwood_tpu.yaml
+++ b/configs/ironwood_tpu.yaml
@@ -1,0 +1,8 @@
+precision_modes:
+  - fp32
+  - bf16
+intervals:
+  K: 1024
+  M: 2048
+sentinel_count: 4
+latency_budget_ms: 50

--- a/configs/majorana1_qpu.yaml
+++ b/configs/majorana1_qpu.yaml
@@ -1,0 +1,9 @@
+precision_modes:
+  - qf64
+  - qf32
+intervals:
+  K: 4096
+  M: 8192
+sentinel_count: 6
+latency_budget_ms: 100
+optional: true

--- a/models/hardware_profiles.py
+++ b/models/hardware_profiles.py
@@ -1,0 +1,85 @@
+"""Utilities for loading accelerator configs and selecting runtime profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - handled in tests
+    import yaml
+except Exception:  # pragma: no cover - fallback when PyYAML missing
+    yaml = None
+
+
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), "configs")
+
+
+@dataclass
+class HardwareConfig:
+    """Configuration for a hardware accelerator."""
+
+    precision_modes: List[str]
+    intervals: Dict[str, int]
+    sentinel_count: int
+    latency_budget_ms: int
+    optional: bool | None = False
+
+
+def _load_raw(path: str) -> Dict[str, Any]:
+    """Load a YAML (or JSON) file into a dictionary."""
+
+    with open(path, "r", encoding="utf-8") as fh:
+        if yaml is not None:
+            return yaml.safe_load(fh)
+        return json.load(fh)
+
+
+def load_hardware_config(name: str) -> HardwareConfig:
+    """Load the configuration for ``name`` from :mod:`configs`.
+
+    Parameters
+    ----------
+    name:
+        Name of the accelerator configuration without extension.
+    """
+
+    path = os.path.join(CONFIG_DIR, f"{name}.yaml")
+    data = _load_raw(path)
+    return HardwareConfig(**data)
+
+
+def select_profile(accelerators: List[str]) -> Dict[str, Any]:
+    """Return profile information based on available accelerators.
+
+    GPU-only environments fall back to the ``Aspen`` profile which
+    provides reduced metrics and wider hysteresis with limited actions.
+    """
+
+    profiles: Dict[str, Any] = {}
+    for acc in accelerators:
+        if acc in ("ironwood_tpu", "majorana1_qpu"):
+            profiles[acc] = load_hardware_config(acc)
+    if not profiles:
+        profiles["profile"] = "aspen"
+        profiles["metrics"] = "reduced"
+        profiles["hysteresis"] = "wide"
+        profiles["actions"] = ["warn", "stabilize"]
+    return profiles
+
+
+def compute(values: List[int], use_accelerator: bool = False) -> List[int]:
+    """Simple computation path used for parity testing."""
+
+    if use_accelerator:
+        import numpy as np
+        arr = np.array(values)
+        return np.square(arr).tolist()
+    return [v * v for v in values]
+
+
+def parity_check(values: List[int]) -> bool:
+    """Ensure host and accelerator paths yield identical results."""
+
+    return compute(values, use_accelerator=False) == compute(values, use_accelerator=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ gymnasium==0.29.1
 numpy==1.26.4
 requests==2.32.3
 GitPython==3.1.40
+PyYAML==6.0.1

--- a/tests/test_hardware_profiles.py
+++ b/tests/test_hardware_profiles.py
@@ -1,0 +1,23 @@
+from models.hardware_profiles import (
+    load_hardware_config,
+    select_profile,
+    parity_check,
+)
+
+
+def test_load_tpu_config():
+    cfg = load_hardware_config("ironwood_tpu")
+    assert "fp32" in cfg.precision_modes
+    assert cfg.intervals["K"] == 1024
+    assert cfg.sentinel_count == 4
+
+
+def test_aspen_profile():
+    profile = select_profile(["gpu"])
+    assert profile["profile"] == "aspen"
+    assert profile["metrics"] == "reduced"
+    assert profile["actions"] == ["warn", "stabilize"]
+
+
+def test_parity_check():
+    assert parity_check([1, 2, 3])


### PR DESCRIPTION
## Summary
- add YAML configs for Ironwood TPU and optional Majorana1 QPU
- implement Aspen profile for GPU-only fallback with reduced metrics and limited actions
- add parity tests between host and accelerator paths

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abee6bf9088333896964364dc8f3f7