### PR TITLE
Add validation experiment framework and reporting templates

### DIFF
--- a/validation/__init__.py
+++ b/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation package containing experiment scripts."""

--- a/validation/decision_matrix_template.csv
+++ b/validation/decision_matrix_template.csv
@@ -1,0 +1,7 @@
+experiment,dataset,delta_lambda,recovery_time,auc,eer,escape_velocity,fp_tpr_drift,qos_delta,overhead,pass,notes,next_steps
+S1,,,,,,,,,,,,
+S2,,,,,,,,,,,,
+S3,,,,,,,,,,,,
+S4,,,,,,,,,,,,
+S5,,,,,,,,,,,,
+S6,,,,,,,,,,,,

--- a/validation/experiments.py
+++ b/validation/experiments.py
@@ -1,0 +1,177 @@
+"""Experiment harness for validation suite S1-S6.
+
+This module defines lightweight experiment functions that mimic the
+behaviour of the full validation pipeline. Each experiment logs the key
+performance indicators (KPIs) requested in the specification and returns
+an :class:`ExperimentResult` object summarising the outcome.
+
+The intent is to provide a reusable scaffold that other teams can extend
+with real evaluation logic. The current implementation uses randomly
+generated numbers to stand in for true metrics so that the scripts remain
+self‑contained and executable in limited environments.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+import csv
+import logging
+import os
+import random
+
+# Configure a basic logger for the module
+logger = logging.getLogger(__name__)
+
+# KPIs that every experiment should report
+KPIS = [
+    "delta_lambda",  # Δλ – change in eigenvalue or risk parameter
+    "recovery_time",  # time to recover after a perturbation
+    "auc",  # area under ROC curve
+    "eer",  # equal error rate
+    "escape_velocity",  # ν̂_r – required escape velocity
+    "fp_tpr_drift",  # drift between false positive and true positive rates
+    "qos_delta",  # quality-of-service delta
+    "overhead",  # computational overhead
+]
+
+@dataclass
+class ExperimentResult:
+    """Container returned by experiment functions."""
+
+    dataset: str
+    metrics: Dict[str, float]
+    passed: bool
+    notes: str = ""
+    next_steps: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Helper utilities
+# ---------------------------------------------------------------------------
+
+def _generate_metrics() -> Dict[str, float]:
+    """Generate placeholder KPI metrics.
+
+    Returns values in [0, 1) to keep things deterministic across tests.
+    """
+
+    return {key: random.random() for key in KPIS}
+
+
+def _simple_pass_fail(metrics: Dict[str, float]) -> bool:
+    """Derive a basic pass/fail decision from metrics.
+
+    The thresholds are intentionally arbitrary and only serve to make the
+    example self-contained. Real experiments should implement domain
+    specific checks.
+    """
+
+    return metrics["delta_lambda"] < 0.5 and metrics["overhead"] < 0.9
+
+
+# ---------------------------------------------------------------------------
+# Experiment implementations
+# ---------------------------------------------------------------------------
+
+def s1_e8_anchor_ablation(dataset: str) -> ExperimentResult:
+    """Experiment S1 – E8 anchor ablation."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+def s2_chiral_inversion_efficacy(dataset: str) -> ExperimentResult:
+    """Experiment S2 – chiral inversion efficacy."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+def s3_cross_architecture_calibration(dataset: str) -> ExperimentResult:
+    """Experiment S3 – cross-architecture calibration."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+def s4_evasion_robustness(dataset: str) -> ExperimentResult:
+    """Experiment S4 – evasion robustness."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+def s5_overhead_profiling(dataset: str) -> ExperimentResult:
+    """Experiment S5 – overhead profiling."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+def s6_integration_safety(dataset: str) -> ExperimentResult:
+    """Experiment S6 – integration safety."""
+    metrics = _generate_metrics()
+    passed = _simple_pass_fail(metrics)
+    return ExperimentResult(dataset=dataset, metrics=metrics, passed=passed)
+
+
+EXPERIMENTS: Dict[str, Callable[[str], ExperimentResult]] = {
+    "S1": s1_e8_anchor_ablation,
+    "S2": s2_chiral_inversion_efficacy,
+    "S3": s3_cross_architecture_calibration,
+    "S4": s4_evasion_robustness,
+    "S5": s5_overhead_profiling,
+    "S6": s6_integration_safety,
+}
+
+
+# ---------------------------------------------------------------------------
+# Runner utilities
+# ---------------------------------------------------------------------------
+
+def run_experiments(dataset_map: Dict[str, str]) -> Dict[str, ExperimentResult]:
+    """Run all experiments using the provided dataset mapping.
+
+    Parameters
+    ----------
+    dataset_map:
+        Mapping from experiment identifiers (e.g. ``"S1"``) to dataset
+        names. A special key ``"default"`` may be used for experiments
+        without an explicit entry.
+    """
+
+    results: Dict[str, ExperimentResult] = {}
+    for exp_id, func in EXPERIMENTS.items():
+        dataset = dataset_map.get(exp_id, dataset_map.get("default", "TruthfulQA"))
+        logger.info("Running %s with dataset %s", exp_id, dataset)
+        res = func(dataset)
+        _log_metrics(exp_id, res)
+        results[exp_id] = res
+    return results
+
+
+def _log_metrics(exp_id: str, result: ExperimentResult) -> None:
+    """Log metrics for an experiment to the module logger."""
+
+    for key, value in result.metrics.items():
+        logger.info("[%s] %s: %.4f", exp_id, key, value)
+
+
+def write_decision_matrix(results: Dict[str, ExperimentResult], path: str) -> None:
+    """Write experiment results to a CSV decision matrix."""
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    fieldnames = ["experiment", "dataset", *KPIS, "pass", "notes", "next_steps"]
+    with open(path, "w", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for exp_id, res in results.items():
+            row = {
+                "experiment": exp_id,
+                "dataset": res.dataset,
+                "pass": res.passed,
+                "notes": res.notes,
+                "next_steps": res.next_steps,
+            }
+            row.update(res.metrics)
+            writer.writerow(row)

--- a/validation/report_template.md
+++ b/validation/report_template.md
@@ -1,0 +1,18 @@
+# Validation Report Template
+
+Summarise the outcome of validation experiments S1–S6. Populate the table
+below with the key metrics and qualitative notes from each run.
+
+| Experiment | Dataset | Pass/Fail | Δλ | Recovery Time | AUC | EER | v̂_r | FP/TPR Drift | QoS Δ | Overhead | Notes | Next Steps |
+|-----------|---------|-----------|---|---------------|-----|-----|-----|---------------|--------|----------|-------|-----------|
+| S1 – E8 anchor ablation | | | | | | | | | | | | |
+| S2 – Chiral inversion efficacy | | | | | | | | | | | | |
+| S3 – Cross-architecture calibration | | | | | | | | | | | | |
+| S4 – Evasion robustness | | | | | | | | | | | | |
+| S5 – Overhead profiling | | | | | | | | | | | | |
+| S6 – Integration safety | | | | | | | | | | | | |
+
+**Notes:**
+- *Pass/Fail* should reflect thresholds agreed upon by the evaluation team.
+- *Next Steps* may include follow-up experiments, mitigation plans, or
+  deployment recommendations.

--- a/validation/run_validation.py
+++ b/validation/run_validation.py
@@ -1,0 +1,57 @@
+"""CLI entrypoint for running validation experiments S1-S6.
+
+The script exposes a thin wrapper around :mod:`validation.experiments`
+that allows callers to specify datasets for each experiment and produces a
+CSV decision matrix with the recorded KPIs.
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from typing import Dict
+
+from .experiments import run_experiments, write_decision_matrix
+
+
+def parse_dataset_map(entries: list[str]) -> Dict[str, str]:
+    """Parse ``EXP=DATASET`` assignments from the CLI."""
+
+    dataset_map: Dict[str, str] = {}
+    for item in entries:
+        if "=" not in item:
+            raise argparse.ArgumentTypeError(
+                f"Invalid dataset mapping '{item}'. Expected EXP=DATASET"
+            )
+        exp, dataset = item.split("=", 1)
+        dataset_map[exp] = dataset
+    return dataset_map
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run validation experiments")
+    parser.add_argument(
+        "--dataset",
+        action="append",
+        default=[],
+        help="Dataset mapping in the form EXP=NAME. Use 'default=NAME' to set a default",
+    )
+    parser.add_argument(
+        "--output",
+        default=os.path.join("validation", "results", "decision_matrix.csv"),
+        help="Path for the decision matrix CSV",
+    )
+    args = parser.parse_args(argv)
+
+    dataset_map = parse_dataset_map(args.dataset)
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    results = run_experiments(dataset_map)
+    write_decision_matrix(results, args.output)
+
+    logging.info("Decision matrix written to %s", args.output)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add experimental harness for S1–S6 validation tasks with KPI logging
- provide CLI to run experiments on configurable datasets and emit decision matrix
- include decision matrix and report templates for summarising pass/fail status

## Testing
- `pytest -q`
- `python -m validation.run_validation --dataset default=TruthfulQA --dataset S2=HumanEval --output validation/results/decision_matrix.csv`

------
https://chatgpt.com/codex/tasks/task_e_68abee6b5a3083338c85a1ad7ae8399b