### PR TITLE
Add tamper-evident telemetry logging

### DIFF
--- a/telemetry/__init__.py
+++ b/telemetry/__init__.py
@@ -1,0 +1,13 @@
+"""Telemetry package providing structured logging with hash chaining."""
+
+from .schema import TelemetryEvent
+from .hash_chain_logger import HashChainLogger
+from .transports import StdoutTransport, FileTransport, HTTPTransport
+
+__all__ = [
+    "TelemetryEvent",
+    "HashChainLogger",
+    "StdoutTransport",
+    "FileTransport",
+    "HTTPTransport",
+]

--- a/telemetry/hash_chain_logger.py
+++ b/telemetry/hash_chain_logger.py
@@ -1,0 +1,90 @@
+"""Hash-chain logger producing tamper-evident telemetry events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Dict, Iterable, Optional
+
+from .schema import TelemetryEvent
+
+
+class HashChainLogger:
+    """Generate telemetry events linked by cryptographic hashes.
+
+    Each call to :meth:`log` produces a :class:`TelemetryEvent` whose ``hash``
+    is derived from the event contents and the previous event's hash. This
+    creates a tamper-evident chain similar to a blockchain.
+
+    Parameters
+    ----------
+    transport:
+        Transport adapter responsible for delivering telemetry records.
+    redact_fields:
+        Iterable of field names to omit from the transmitted record. The hash
+        is computed over the full event **before** redaction.
+    """
+
+    def __init__(
+        self,
+        transport: Any,
+        *,
+        redact_fields: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.transport = transport
+        self.prev_hash: Optional[str] = None
+        self.step = 0
+        self.redact_fields = set(redact_fields or [])
+
+    # Internal -----------------------------------------------------------------
+    def _canonical_dict(self, data: Dict[str, Any]) -> Dict[str, Any]:
+        canon = {}
+        for key, value in data.items():
+            if isinstance(value, datetime):
+                canon[key] = value.isoformat()
+            else:
+                canon[key] = value
+        return canon
+
+    # Public API ----------------------------------------------------------------
+    def log(
+        self,
+        *,
+        model_id: str,
+        model_version: str,
+        detector_metrics: Dict[str, float],
+        action: str,
+    ) -> TelemetryEvent:
+        """Create and dispatch a new telemetry event.
+
+        Returns the full event (before redaction).
+        """
+
+        self.step += 1
+        event_dict: Dict[str, Any] = {
+            "step": self.step,
+            "model_id": model_id,
+            "model_version": model_version,
+            "detector_metrics": detector_metrics,
+            "action": action,
+            "timestamp": datetime.utcnow(),
+            "prev_hash": self.prev_hash,
+        }
+
+        canon = self._canonical_dict(event_dict)
+        serialized = json.dumps(canon, sort_keys=True)
+        current_hash = hashlib.sha256(serialized.encode()).hexdigest()
+        event_dict["hash"] = current_hash
+
+        event = TelemetryEvent(**event_dict)
+
+        # Prepare redacted payload for transport
+        payload = event.model_dump()
+        for field in self.redact_fields:
+            payload.pop(field, None)
+
+        payload = self._canonical_dict(payload)
+        self.transport.send(payload)
+        self.prev_hash = current_hash
+        return event

--- a/telemetry/schema.py
+++ b/telemetry/schema.py
@@ -1,0 +1,35 @@
+"""Pydantic models for telemetry events."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, Optional
+
+from pydantic import BaseModel, Field
+
+
+class TelemetryEvent(BaseModel):
+    """Structured telemetry event following Appendix P schema."""
+
+    step: int = Field(..., description="Incremental step number for the run")
+    model_id: str = Field(..., description="Identifier for the model generating the event")
+    model_version: str = Field(..., description="Version of the model generating the event")
+    detector_metrics: Dict[str, float] = Field(
+        default_factory=dict, description="Metrics reported by detectors"
+    )
+    action: str = Field(..., description="Action taken at this step")
+    timestamp: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="UTC timestamp when the event was generated",
+    )
+    prev_hash: Optional[str] = Field(
+        default=None, description="Hash of the previous telemetry event"
+    )
+    hash: Optional[str] = Field(
+        default=None, description="Hash of the current telemetry event"
+    )
+
+    class Config:
+        json_schema_extra = {
+            "description": "Telemetry event schema matching Appendix P with tamper-evident fields."
+        }

--- a/telemetry/transports.py
+++ b/telemetry/transports.py
@@ -1,0 +1,45 @@
+"""Transport adapters for telemetry dispatch."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import requests
+
+
+class TransportProtocol:
+    """Simple protocol representing a telemetry transport."""
+
+    def send(self, record: Dict[str, Any]) -> None:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class StdoutTransport(TransportProtocol):
+    """Write telemetry records to stdout as JSON."""
+
+    def send(self, record: Dict[str, Any]) -> None:
+        print(json.dumps(record))
+
+
+class FileTransport(TransportProtocol):
+    """Append telemetry records to a file, one JSON object per line."""
+
+    def __init__(self, path: str | Path) -> None:
+        self.path = Path(path)
+
+    def send(self, record: Dict[str, Any]) -> None:
+        with self.path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+
+class HTTPTransport(TransportProtocol):
+    """POST telemetry records to an HTTP endpoint."""
+
+    def __init__(self, url: str, *, session: Optional[requests.Session] = None) -> None:
+        self.url = url
+        self.session = session or requests.Session()
+
+    def send(self, record: Dict[str, Any]) -> None:
+        self.session.post(self.url, json=record, timeout=5)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,34 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from telemetry import HashChainLogger, FileTransport
+
+
+def test_hash_chain_and_redaction(tmp_path):
+    log_file = tmp_path / "telemetry.log"
+    transport = FileTransport(log_file)
+    logger = HashChainLogger(transport, redact_fields={"detector_metrics"})
+
+    event1 = logger.log(
+        model_id="m1",
+        model_version="1.0",
+        detector_metrics={"score": 0.5},
+        action="step1",
+    )
+    event2 = logger.log(
+        model_id="m1",
+        model_version="1.0",
+        detector_metrics={"score": 0.8},
+        action="step2",
+    )
+
+    assert event2.prev_hash == event1.hash
+
+    lines = log_file.read_text().strip().splitlines()
+    assert len(lines) == 2
+    for line in lines:
+        record = json.loads(line)
+        assert "detector_metrics" not in record


### PR DESCRIPTION
## Summary
- add telemetry package with Pydantic schema for per-step logs
- implement hash-chain logger supporting field redaction
- provide stdout, file and HTTP transport adapters
- cover telemetry logging with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abee695d588333b822d10f353e29e7