### PR TITLE
Add egregore stability metrics and composite detector

### DIFF
--- a/stability_core/__init__.py
+++ b/stability_core/__init__.py
@@ -1,1 +1,6 @@
 """Stability core utilities."""
+
+from .egregore import EgDetect, EgState, EgMitigate, EgAudit
+
+__all__ = ["EgDetect", "EgState", "EgMitigate", "EgAudit"]
+

--- a/stability_core/__init__.py
+++ b/stability_core/__init__.py
@@ -3,4 +3,3 @@
 from .egregore import EgDetect, EgState, EgMitigate, EgAudit
 
 __all__ = ["EgDetect", "EgState", "EgMitigate", "EgAudit"]
-

--- a/stability_core/__init__.py
+++ b/stability_core/__init__.py
@@ -1,0 +1,1 @@
+"""Stability core utilities."""

--- a/stability_core/egregore/__init__.py
+++ b/stability_core/egregore/__init__.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Dict, Any
+
+import numpy as np
+
+from .metrics import (
+    phase_order,
+    spectral_capacity,
+    mutual_information,
+    wavelet_burst_energy,
+    entropy_slope,
+)
+from .detector import CompositeDetector
+
+# Default thresholds for metrics: (warn, escalate)
+_THRESHOLDS = {
+    "phase_order": (0.7, 0.9),
+    "spectral_capacity": (1.5, 2.0),
+    "mutual_info": (0.3, 0.5),
+    "wavelet_energy": (10.0, 20.0),
+    "entropy_slope": (0.01, 0.02),
+}
+
+_detector = CompositeDetector(_THRESHOLDS, dwell=3)
+
+_log_file = Path(__file__).resolve().with_name("egregore.log")
+if _log_file.exists():
+    try:
+        last_line = _log_file.read_text().splitlines()[-1]
+        _last_hash = last_line.split()[0]
+    except Exception:  # pragma: no cover
+        _last_hash = "0"
+else:
+    _last_hash = "0"
+
+
+def EgAudit(message: str) -> str:
+    """Append message to hash-chained log and return digest."""
+    global _last_hash
+    record = f"{message}|prev={_last_hash}"
+    digest = hashlib.sha256(record.encode()).hexdigest()
+    with _log_file.open("a") as fh:
+        fh.write(f"{digest} {record}\n")
+    _last_hash = digest
+    return digest
+
+
+def EgMitigate(level: str) -> Dict[str, Any]:
+    """Perform mitigation action and audit it."""
+    EgAudit(f"mitigation:{level}")
+    return {"action": level}
+
+
+def EgDetect(signal: np.ndarray, matrix: np.ndarray, other: np.ndarray) -> Dict[str, float]:
+    """Compute metrics and run composite detector."""
+    metrics = {
+        "phase_order": phase_order(signal),
+        "spectral_capacity": spectral_capacity(matrix),
+        "mutual_info": mutual_information(signal, other),
+        "wavelet_energy": wavelet_burst_energy(signal),
+        "entropy_slope": entropy_slope(signal),
+    }
+    action = _detector.check(metrics)
+    if action:
+        EgMitigate(action)
+    return metrics
+
+
+def EgState() -> str:
+    """Return current detector state."""
+    return _detector.state
+
+
+__all__ = [
+    "EgDetect",
+    "EgState",
+    "EgMitigate",
+    "EgAudit",
+    "CompositeDetector",
+    "phase_order",
+    "spectral_capacity",
+    "mutual_information",
+    "wavelet_burst_energy",
+    "entropy_slope",
+]

--- a/stability_core/egregore/__init__.py
+++ b/stability_core/egregore/__init__.py
@@ -49,13 +49,15 @@ def EgAudit(message: str) -> str:
 
 
 def EgMitigate(level: str) -> Dict[str, Any]:
-    """Perform mitigation action and audit it."""
+    """Perform mitigation action (warn, stabilize, escalate) and audit it."""
     EgAudit(f"mitigation:{level}")
     return {"action": level}
 
 
-def EgDetect(signal: np.ndarray, matrix: np.ndarray, other: np.ndarray) -> Dict[str, float]:
-    """Compute metrics and run composite detector."""
+def EgDetect(
+    signal: np.ndarray, matrix: np.ndarray, other: np.ndarray
+) -> Dict[str, Any]:
+    """Compute metrics, run detector, and return metrics and action."""
     metrics = {
         "phase_order": phase_order(signal),
         "spectral_capacity": spectral_capacity(matrix),
@@ -66,7 +68,7 @@ def EgDetect(signal: np.ndarray, matrix: np.ndarray, other: np.ndarray) -> Dict[
     action = _detector.check(metrics)
     if action:
         EgMitigate(action)
-    return metrics
+    return {"metrics": metrics, "action": action}
 
 
 def EgState() -> str:

--- a/stability_core/egregore/__init__.py
+++ b/stability_core/egregore/__init__.py
@@ -81,10 +81,4 @@ __all__ = [
     "EgState",
     "EgMitigate",
     "EgAudit",
-    "CompositeDetector",
-    "phase_order",
-    "spectral_capacity",
-    "mutual_information",
-    "wavelet_burst_energy",
-    "entropy_slope",
 ]

--- a/stability_core/egregore/__init__.py
+++ b/stability_core/egregore/__init__.py
@@ -77,6 +77,11 @@ def EgState() -> str:
 
 
 __all__ = [
+    "phase_order",
+    "spectral_capacity",
+    "mutual_information",
+    "wavelet_burst_energy",
+    "entropy_slope",
     "EgDetect",
     "EgState",
     "EgMitigate",

--- a/stability_core/egregore/detector.py
+++ b/stability_core/egregore/detector.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+
+@dataclass
+class CompositeDetector:
+    """Composite detector with hysteresis and dwell timers."""
+
+    thresholds: Dict[str, Tuple[float, float]]
+    dwell: int = 3
+    counters: Dict[str, int] = field(default_factory=dict)
+    state: str = "normal"
+
+    def __post_init__(self) -> None:
+        self.counters = {k: 0 for k in self.thresholds}
+
+    def check(self, metrics: Dict[str, float]) -> str | None:
+        """Evaluate metrics and return mitigation level."""
+        action = None
+        for key, value in metrics.items():
+            warn, escalate = self.thresholds.get(key, (None, None))
+            if escalate is not None and value > escalate:
+                self.counters[key] += 1
+                if self.counters[key] >= self.dwell:
+                    action = "escalate"
+                    self.counters[key] = 0
+                    self.state = "escalate"
+            elif warn is not None and value > warn:
+                self.counters[key] += 1
+                if self.counters[key] >= self.dwell and action != "escalate":
+                    action = "stabilize"
+                    self.counters[key] = 0
+                    self.state = "stabilize"
+            else:
+                self.counters[key] = 0
+        return action

--- a/stability_core/egregore/detector.py
+++ b/stability_core/egregore/detector.py
@@ -10,11 +10,14 @@ class CompositeDetector:
 
     thresholds: Dict[str, Tuple[float, float]]
     dwell: int = 3
-    counters: Dict[str, int] = field(default_factory=dict)
+    warn_counters: Dict[str, int] = field(default_factory=dict)
+    esc_counters: Dict[str, int] = field(default_factory=dict)
+    safe_counter: int = 0
     state: str = "normal"
 
     def __post_init__(self) -> None:
-        self.counters = {k: 0 for k in self.thresholds}
+        self.warn_counters = {k: 0 for k in self.thresholds}
+        self.esc_counters = {k: 0 for k in self.thresholds}
 
     def check(self, metrics: Dict[str, float]) -> str | None:
         """Evaluate metrics and return mitigation level."""
@@ -22,17 +25,40 @@ class CompositeDetector:
         for key, value in metrics.items():
             warn, escalate = self.thresholds.get(key, (None, None))
             if escalate is not None and value > escalate:
-                self.counters[key] += 1
-                if self.counters[key] >= self.dwell:
-                    action = "escalate"
-                    self.counters[key] = 0
-                    self.state = "escalate"
-            elif warn is not None and value > warn:
-                self.counters[key] += 1
-                if self.counters[key] >= self.dwell and action != "escalate":
-                    action = "stabilize"
-                    self.counters[key] = 0
-                    self.state = "stabilize"
+                self.esc_counters[key] += 1
             else:
-                self.counters[key] = 0
+                self.esc_counters[key] = 0
+
+            if warn is not None and value > warn:
+                self.warn_counters[key] += 1
+            else:
+                self.warn_counters[key] = 0
+
+        if any(c >= self.dwell for c in self.esc_counters.values()):
+            action = "escalate"
+            self.state = "escalate"
+            self.safe_counter = 0
+            for k in self.warn_counters:
+                self.warn_counters[k] = 0
+                self.esc_counters[k] = 0
+        elif any(c >= self.dwell for c in self.warn_counters.values()):
+            action = "warn"
+            self.state = "warn"
+            self.safe_counter = 0
+        else:
+            if all(
+                metrics[k] < self.thresholds[k][0]
+                for k in metrics
+                if self.thresholds[k][0] is not None
+            ):
+                self.safe_counter += 1
+                if self.safe_counter >= self.dwell and self.state != "normal":
+                    action = "stabilize"
+                    self.state = "normal"
+                    self.safe_counter = 0
+                    for k in self.warn_counters:
+                        self.warn_counters[k] = 0
+                        self.esc_counters[k] = 0
+            else:
+                self.safe_counter = 0
         return action

--- a/stability_core/egregore/metrics.py
+++ b/stability_core/egregore/metrics.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+
+def phase_order(phases: np.ndarray) -> float:
+    """Compute Kuramoto phase order parameter r(t).
+
+    Parameters
+    ----------
+    phases: np.ndarray
+        Array of oscillator phases in radians.
+    Returns
+    -------
+    float
+        Order parameter magnitude in [0,1].
+    """
+    if phases.size == 0:
+        return 0.0
+    order = np.abs(np.sum(np.exp(1j * phases)) / phases.size)
+    return float(order)
+
+
+def spectral_capacity(matrix: np.ndarray) -> float:
+    """Largest eigenvalue (spectral capacity) of a matrix."""
+    if matrix.size == 0:
+        return 0.0
+    vals = np.linalg.eigvals(matrix)
+    return float(np.max(np.real(vals)))
+
+
+def mutual_information(x: np.ndarray, y: np.ndarray, bins: int = 32) -> float:
+    """Estimate mutual information between two signals."""
+    if x.size == 0 or y.size == 0:
+        return 0.0
+    c_xy = np.histogram2d(x, y, bins)[0]
+    p_xy = c_xy / np.sum(c_xy)
+    p_x = np.sum(p_xy, axis=1)[:, None]
+    p_y = np.sum(p_xy, axis=0)[None, :]
+    nz = p_xy > 0
+    mi = np.sum(p_xy[nz] * np.log(p_xy[nz] / (p_x * p_y)[nz]))
+    return float(mi)
+
+
+def wavelet_burst_energy(signal: np.ndarray, width: int = 5) -> float:
+    """Compute energy of a Morlet wavelet burst in the signal."""
+    if signal.size == 0:
+        return 0.0
+    t = np.arange(-5 * width, 5 * width)
+    morlet = np.exp(-t**2 / (2 * width**2)) * np.cos(5 * t)
+    conv = np.convolve(signal, morlet, mode="same")
+    return float(np.sum(conv ** 2))
+
+
+def entropy_slope(signal: np.ndarray, window: int = 50) -> float:
+    """Slope of Shannon entropy over sliding windows."""
+    n = signal.size
+    if n < window * 2:
+        return 0.0
+    entropies = []
+    for i in range(0, n - window + 1):
+        segment = signal[i : i + window]
+        hist, _ = np.histogram(segment, bins="auto", density=True)
+        p = hist[hist > 0]
+        entropies.append(-np.sum(p * np.log(p)))
+    x = np.arange(len(entropies))
+    slope, _ = np.polyfit(x, entropies, 1)
+    return float(slope)


### PR DESCRIPTION
## Summary
- add phase order, spectral capacity, mutual information, wavelet energy, and entropy slope metrics
- implement CompositeDetector with hysteresis thresholds and dwell timers
- expose EgDetect, EgState, EgMitigate, and EgAudit with hash-chained logging

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68abcc007f0c83338a0d06483e893063