### PR TITLE
Centralize router prefixes in main

### DIFF
--- a/orion_api/routers/egregore_defense.py
+++ b/orion_api/routers/egregore_defense.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 
 from models.egregore_defense import evaluate_threat
 
-router = APIRouter(prefix="/api/v1/egregore", tags=["Egregore Defense"])
+router = APIRouter()
 
 @router.get("/shield")
 async def activate_shield(threat: float = 0.0):

--- a/orion_api/routers/manifold_router.py
+++ b/orion_api/routers/manifold_router.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/api/v1/manifold_router", tags=["Manifold Router"])
+router = APIRouter()
 
 @router.post("/distribute_task")
 async def distribute_task(task: str, depth: int):

--- a/orion_api/routers/quantum_sync.py
+++ b/orion_api/routers/quantum_sync.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 
 from models.quantum_sync import get_sync_status
 
-router = APIRouter(prefix="/api/v1/quantum_sync", tags=["Quantum Sync"])
+router = APIRouter()
 
 @router.get("/status")
 async def get_status():

--- a/orion_api/routers/recursive_trust.py
+++ b/orion_api/routers/recursive_trust.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 
 from models.recursive_trust import assess_score
 
-router = APIRouter(prefix="/api/v1/trust", tags=["Recursive Trust"])
+router = APIRouter()
 
 @router.post("/assess")
 async def assess_trust(score: int):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -19,3 +19,29 @@ def test_telemetry_endpoint():
     response = client.get("/telemetry")
     assert response.status_code == 200
     assert "telemetry" in response.json()
+
+
+def test_quantum_sync_status_endpoint():
+    response = client.get("/quantum-sync/status")
+    assert response.status_code == 200
+    assert "status" in response.json()
+
+
+def test_recursive_trust_assess_endpoint():
+    response = client.post("/trust/assess", params={"score": 80})
+    assert response.status_code == 200
+    assert response.json().get("score") == 80
+
+
+def test_egregore_shield_endpoint():
+    response = client.get("/egregore/shield", params={"threat": 0.8})
+    assert response.status_code == 200
+    assert "action" in response.json()
+
+
+def test_manifold_distribute_task_endpoint():
+    response = client.post(
+        "/manifold/distribute_task", params={"task": "test", "depth": 1}
+    )
+    assert response.status_code == 200
+    assert "message" in response.json()


### PR DESCRIPTION
## Summary
- Remove prefix and tags from individual routers so all prefixes are defined in `main.py`
- Add tests verifying endpoint paths `/quantum-sync/status`, `/trust/assess`, `/egregore/shield`, and `/manifold/distribute_task`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc57bad390833381402f658aa5606f