### PR TITLE
Expose knowledge expansion and perception routers

### DIFF
--- a/orion_api/main.py
+++ b/orion_api/main.py
@@ -5,6 +5,8 @@ from orion_api.routers import (
     recursive_trust,
     egregore_defense,
     manifold_router,
+    knowledge_expansion,
+    perception,
 )
 from models.stability_core import stability_core
 
@@ -16,6 +18,8 @@ app.include_router(quantum_sync.router, prefix="/quantum-sync", tags=["Quantum S
 app.include_router(recursive_trust.router, prefix="/trust", tags=["Recursive Trust"])
 app.include_router(egregore_defense.router, prefix="/egregore", tags=["Egregore Defense"])
 app.include_router(manifold_router.router, prefix="/manifold", tags=["Manifold Routing"])
+app.include_router(knowledge_expansion.router, prefix="/api/v1/knowledge", tags=["Knowledge Expansion"])
+app.include_router(perception.router, prefix="/api/v1/perception", tags=["Perception"])
 
 @app.get("/")
 async def root():

--- a/orion_api/routers/knowledge_expansion.py
+++ b/orion_api/routers/knowledge_expansion.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/api/v1/knowledge", tags=["Knowledge Expansion"])
+router = APIRouter()
 
 @router.post("/learn")
 async def learn(info: str):

--- a/orion_api/routers/perception.py
+++ b/orion_api/routers/perception.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter
 
-router = APIRouter(prefix="/api/v1/perception", tags=["Perception"])
+router = APIRouter()
 
 @router.get("/ping")
 async def ping():


### PR DESCRIPTION
## Summary
- expose knowledge expansion and perception routers through FastAPI
- standardize routers to rely on main for prefixes/tags

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc740d62c883338f27dcdd783a5039