### PR TITLE
Add Pydantic settings and document configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ O.R.I.O.N. ∞ (Omniversal Recursive Intelligence and Ontological Network) is an
     ```
 2. Run the API:
     ```bash
-    uvicorn orion_api.main:app --host 0.0.0.0 --port 8080
+    uvicorn orion_api.main:app --host $ORION_HOST --port $ORION_PORT
     ```
 3. Deploy with Docker:
     ```bash
@@ -28,6 +28,25 @@ O.R.I.O.N. ∞ (Omniversal Recursive Intelligence and Ontological Network) is an
     kubectl apply -f deployment/orion-deployment.yml
     ```
 
+## Configuration
+Runtime settings are managed via `orion_api/config.py`, which uses
+Pydantic's `BaseSettings`.  Values can be supplied through environment
+variables or a `.env` file.  The most common options are:
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `ORION_HOST` | Host interface for the API | `0.0.0.0` |
+| `ORION_PORT` | Port the API listens on | `8080` |
+| `ORION_MODEL_DIR` | Directory where models are stored | `models` |
+| `ORION_RECURSIVE_MODEL_PATH` | Path to the recursive model file | `models/recursive_live_optimization_model.zip` |
+
+Example `.env` file:
+
+```env
+ORION_HOST=127.0.0.1
+ORION_PORT=8000
+```
+
 ## Benchmarking
 Run recursive AI performance tests:
 ```bash
@@ -37,7 +56,7 @@ python benchmarks/benchmark_recursive.py
 ## Testing
 Install minimal test dependencies and run the unit tests:
 ```bash
-pip install fastapi==0.115.11 httpx==0.27.0 pytest==8.0.0
+pip install fastapi==0.115.11 httpx==0.27.0 pytest==8.0.0 pydantic-settings==2.10.1
 pytest -q
 ```
 The pinned `httpx` version has been tested with FastAPI's `TestClient` to ensure

--- a/models/recursive_ai_model.py
+++ b/models/recursive_ai_model.py
@@ -2,6 +2,7 @@ import os
 import urllib.request
 import numpy as np
 from models.stability_core import stability_core
+from orion_api.config import settings
 
 try:
     from stable_baselines3 import PPO
@@ -10,8 +11,8 @@ except ImportError:  # Fallback when dependencies are missing
     PPO = None
     gym = None
 
-MODEL_DIR = "models"
-MODEL_PATH = os.path.join(MODEL_DIR, "recursive_live_optimization_model.zip")
+MODEL_DIR = settings.model_dir
+MODEL_PATH = settings.recursive_model_path
 MODEL_URL = os.getenv(
     "RECURSIVE_MODEL_URL",
     "https://github.com/HFCTM-II-ORION/HFCTM-II-ORION/releases/latest/download/recursive_live_optimization_model.zip",

--- a/orion_api/config.py
+++ b/orion_api/config.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    """Application configuration using environment variables.
+
+    Values can be overridden via environment variables with the prefix
+    ``ORION_`` or by providing a ``.env`` file in the project root.
+    """
+
+    host: str = "0.0.0.0"
+    port: int = 8080
+    model_dir: Path = Path("models")
+    recursive_model_path: Path = Path("models/recursive_live_optimization_model.zip")
+
+    model_config = SettingsConfigDict(
+        env_prefix="ORION_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+    )
+
+
+# Global settings instance
+settings = Settings()

--- a/orion_api/main.py
+++ b/orion_api/main.py
@@ -9,6 +9,7 @@ from orion_api.routers import (
     perception,
 )
 from models.stability_core import stability_core
+from orion_api.config import settings
 
 app = FastAPI(title="O.R.I.O.N. ∞ API")
 
@@ -23,7 +24,11 @@ app.include_router(perception.router, prefix="/api/v1/perception", tags=["Percep
 
 @app.get("/")
 async def root():
-    return {"message": "Welcome to O.R.I.O.N. ∞ API"}
+    return {
+        "message": f"Welcome to O.R.I.O.N. ∞ API",
+        "host": settings.host,
+        "port": settings.port,
+    }
 
 
 @app.get("/health")

--- a/orion_api/orion_api.py
+++ b/orion_api/orion_api.py
@@ -3,6 +3,7 @@ from pydantic import BaseModel
 import uvicorn
 import torch
 import numpy as np
+from orion_api.config import settings
 
 app = FastAPI(title="O.R.I.O.N. ∞ API", version="1.0")
 
@@ -15,4 +16,4 @@ async def recursive_infer(request: RecursiveRequest):
     return {"response": f"Recursive Expansion → {request.query}", "depth": request.depth + 1}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    uvicorn.run(app, host=settings.host, port=settings.port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 torch==2.6.0
 fastapi==0.115.11
 uvicorn==0.34.0
-pydantic==2.6.4
+pydantic==2.11.7
+pydantic-settings==2.10.1
 networkx==3.2.1
 sympy==1.13.1
 matplotlib==3.8.2


### PR DESCRIPTION
## Summary
- add centralized BaseSettings with host, port and model paths
- wire configuration into FastAPI entrypoints and model loader
- document environment variables and update requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bc8ba69a8083339f626b43c8507466