### PR TITLE
Use Azure Quantum to report backend sync metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ The repository previously listed Hugging Face's `transformers` library in
 `requirements.txt`, but no modules actually used it. The dependency has been
 removed to keep installation lightweight.
 
+## Azure Quantum Integration
+Running against real hardware requires Microsoft Azure Quantum credentials.  Set
+the following environment variables to enable the `majorana1` backend used by
+the `/quantum-sync/status` endpoint:
+
+| Variable | Description |
+|----------|-------------|
+| `AZURE_QUANTUM_SUBSCRIPTION_ID` | Azure subscription identifier |
+| `AZURE_QUANTUM_RESOURCE_GROUP` | Resource group containing the workspace |
+| `AZURE_QUANTUM_WORKSPACE_NAME` | Azure Quantum workspace name |
+| `AZURE_QUANTUM_LOCATION` | (Optional) workspace region, e.g. `eastus` |
+
+Authentication relies on [Azure Identity's `DefaultAzureCredential`][dac].  In
+most deployments this means providing the standard service principal secrets:
+`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET`.
+
+[dac]: https://learn.microsoft.com/python/api/overview/azure/identity-readme
+
 ## Automation Scripts
 Scripts such as `commit_file.py` can automatically commit changes. To push to a
 remote repository these scripts require a `GITHUB_TOKEN` environment variable.

--- a/models/quantum_sync.py
+++ b/models/quantum_sync.py
@@ -1,14 +1,73 @@
-"""Utilities for simulating quantum synchronization events."""
+"""Azure Quantum integration for synchronization checks."""
 
 from __future__ import annotations
 
-import random
+import os
+from typing import Any
 
 
-def get_sync_status() -> dict[str, float | str]:
-    """Return a mocked status of the quantum sync subsystem."""
+def get_sync_status() -> dict[str, Any]:
+    """Return status and basic metrics from the ``majorana1`` backend.
 
-    return {
-        "status": "operational",
-        "coherence_level": round(random.uniform(0.8, 1.0), 3),
-    }
+    The function attempts to authenticate against Azure Quantum using
+    subscription, resource group and workspace values supplied via environment
+    variables.  If the Azure Quantum SDK or credentials are unavailable the
+    error is captured and returned instead of raising an exception.
+    """
+
+    # Import is deferred so that unit tests without the SDK installed do not
+    # immediately fail.
+    try:
+        from azure.quantum.qiskit import AzureQuantumProvider  # type: ignore
+        from qiskit import QuantumCircuit  # type: ignore
+    except Exception as exc:  # pragma: no cover - executed when SDK missing
+        return {"status": "error", "message": f"Azure Quantum SDK not available: {exc}"}
+
+    subscription_id = os.getenv("AZURE_QUANTUM_SUBSCRIPTION_ID")
+    resource_group = os.getenv("AZURE_QUANTUM_RESOURCE_GROUP")
+    workspace = os.getenv("AZURE_QUANTUM_WORKSPACE_NAME")
+    location = os.getenv("AZURE_QUANTUM_LOCATION", "eastus")
+
+    try:
+        provider = AzureQuantumProvider(
+            subscription_id=subscription_id,
+            resource_group=resource_group,
+            name=workspace,
+            location=location,
+        )
+
+        backend = provider.get_backend("majorana1")
+
+        # Minimal GHZ-state circuit to verify backend responsiveness
+        circuit = QuantumCircuit(3, 3)
+        circuit.h(0)
+        circuit.cx(0, 1)
+        circuit.cx(0, 2)
+        circuit.measure(range(3), range(3))
+
+        job = backend.run(circuit, shots=1)
+
+        metrics: dict[str, Any] = {}
+        if hasattr(job, "metrics"):
+            try:
+                metrics = job.metrics()
+            except Exception:  # pragma: no cover - metric retrieval optional
+                metrics = {}
+
+        status = "unknown"
+        if hasattr(job, "status"):
+            try:
+                st = job.status()
+                status = getattr(st, "name", str(st))
+            except Exception:  # pragma: no cover
+                status = "unknown"
+
+        return {
+            "status": status,
+            "latency": metrics.get("latency"),
+            "coherence_time": metrics.get("coherence_time"),
+        }
+
+    except Exception as exc:  # pragma: no cover - network/auth failures
+        return {"status": "error", "message": str(exc)}
+

--- a/orion_api/routers/quantum_sync.py
+++ b/orion_api/routers/quantum_sync.py
@@ -4,9 +4,16 @@ from models.quantum_sync import get_sync_status
 
 router = APIRouter()
 
+
 @router.get("/status")
 async def get_status():
-    """Return status of quantum synchronization subsystem."""
+    """Expose real backend latency and coherence statistics when available."""
 
-    return get_sync_status()
+    status = get_sync_status()
+    return {
+        "status": status.get("status"),
+        "latency": status.get("latency"),
+        "coherence_time": status.get("coherence_time"),
+        "message": status.get("message"),
+    }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,9 @@ networkx==3.2.1
 sympy==1.13.1
 matplotlib==3.8.2
 qiskit==0.45.0
+azure-quantum==3.2.0
+qsharp==1.20.0
+pyqir==0.10.9
 pytest==8.0.0
 httpx==0.27.0
 stable-baselines3==2.2.1


### PR DESCRIPTION
## Summary
- replace mocked quantum sync status with Azure Quantum `majorana1` backend job
- expose latency and coherence metrics through `/quantum-sync/status`
- document Azure Quantum credentials and required environment variables

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcbdb7f0f483339b82224da290bf3d