### PR TITLE
Add production Kubernetes manifest and deployment docs

### DIFF
--- a/deployment/hfctm-ii-production.yaml
+++ b/deployment/hfctm-ii-production.yaml
@@ -1,0 +1,143 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hfctm-ii-config
+  labels:
+    app: hfctm-ii
+data:
+  LOG_LEVEL: "info"
+  MODEL_VARIANT: "production"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hfctm-ii
+  labels:
+    app: hfctm-ii
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: hfctm-ii
+  template:
+    metadata:
+      labels:
+        app: hfctm-ii
+    spec:
+      nodeSelector:
+        qpu: "majorana1"
+        tpu: "ironwood-tpu"
+      tolerations:
+        - key: "qpu"
+          operator: "Equal"
+          value: "majorana1"
+          effect: "NoSchedule"
+        - key: "tpu"
+          operator: "Equal"
+          value: "ironwood-tpu"
+          effect: "NoSchedule"
+      containers:
+        - name: hfctm-ii
+          image: your-registry/hfctm-ii:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: AZURE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: azure-credentials
+                  key: client-id
+            - name: AZURE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: azure-credentials
+                  key: client-secret
+            - name: GOOGLE_APPLICATION_CREDENTIALS
+              valueFrom:
+                secretKeyRef:
+                  name: google-credentials
+                  key: service-account.json
+          resources:
+            requests:
+              cpu: "500m"
+              memory: "512Mi"
+            limits:
+              cpu: "1"
+              memory: "1Gi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: hfctm-ii
+  labels:
+    app: hfctm-ii
+spec:
+  selector:
+    app: hfctm-ii
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+  type: ClusterIP
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: hfctm-ii
+  labels:
+    app: hfctm-ii
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: hfctm-ii
+  minReplicas: 3
+  maxReplicas: 10
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 75
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: hfctm-ii-allow
+  labels:
+    app: hfctm-ii
+spec:
+  podSelector:
+    matchLabels:
+      app: hfctm-ii
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    - to:
+        - podSelector: {}
+      ports:
+        - protocol: TCP
+          port: 80
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: hfctm-ii
+  labels:
+    app: hfctm-ii
+spec:
+  selector:
+    matchLabels:
+      app: hfctm-ii
+  endpoints:
+    - port: http
+      interval: 30s

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,43 @@
+# HFCTM-II Production Deployment
+
+This guide walks through deploying the HFCTM-II service to a Kubernetes cluster.
+
+## Prerequisites
+
+- A Kubernetes cluster with access to `majorana1` QPU and `ironwood-tpu` nodes.
+- The [`azure-credentials`](#creating-required-secrets) and `google-credentials` secrets containing service credentials.
+- `kubectl` configured to access the target cluster.
+
+## Creating Required Secrets
+
+Create the Azure and Google secrets before deploying:
+
+```bash
+kubectl create secret generic azure-credentials \
+  --from-literal=client-id=<your-azure-client-id> \
+  --from-literal=client-secret=<your-azure-client-secret>
+
+kubectl create secret generic google-credentials \
+  --from-file=service-account.json=<path-to-google-service-account-json>
+```
+
+## Apply the Deployment
+
+The manifest includes a `ConfigMap`, `Deployment`, `Service`, `HPA`, `NetworkPolicy`, and `ServiceMonitor`.
+Deploy everything with:
+
+```bash
+kubectl apply -f deployment/hfctm-ii-production.yaml
+```
+
+The deployment uses node selectors and tolerations for `majorana1` QPU and `ironwood-tpu` nodes to ensure pods schedule on the correct hardware.
+
+## Verifying
+
+Check the status of the deployment and service:
+
+```bash
+kubectl get pods,svc,hpa,netpol,servicemonitor -l app=hfctm-ii
+```
+
+Metrics are scraped via the `ServiceMonitor`, so ensure Prometheus is configured in the cluster.


### PR DESCRIPTION
## Summary
- add hfctm-ii-production Kubernetes manifest with ConfigMap, Deployment, Service, HPA, NetworkPolicy, and ServiceMonitor
- parametrize Azure and Google credentials via Secrets
- document production deployment steps

## Testing
- `pip install transformers accelerate sentencepiece`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcc2d92e5c8333ba9769777ba26489