### PR TITLE
feat: add asynchronous safety core

### DIFF
--- a/orion_api/__init__.py
+++ b/orion_api/__init__.py
@@ -1,1 +1,18 @@
+"""Orion API package exports."""
+
+from .hfctm_safety import (
+    HFCTMII_SafetyCore,
+    SafetyConfig,
+    init_safety_core,
+    safety_core,
+    safety_overhead_gauge,
+)
+
+__all__ = [
+    "HFCTMII_SafetyCore",
+    "SafetyConfig",
+    "init_safety_core",
+    "safety_core",
+    "safety_overhead_gauge",
+]
 


### PR DESCRIPTION
## Summary
- implement `SafetyConfig` dataclass for hardware toggles and thresholds
- add async `HFCTMII_SafetyCore.safety_check` with Lyapunov, wavelet and egregore logic
- export safety utilities via `orion_api.__init__`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcd501b56c833397e4cbe606b2355f