### PR TITLE
Use lightweight requirements for CI

### DIFF
--- a/.github/workflows/ai_automation.yml
+++ b/.github/workflows/ai_automation.yml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -44,8 +42,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -73,8 +69,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v3
@@ -102,8 +96,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        with:
-          ref: main
 
       - name: Set up Python
         uses: actions/setup-python@v3

--- a/.github/workflows/ai_automation.yml
+++ b/.github/workflows/ai_automation.yml
@@ -23,8 +23,16 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-ci.txt
 
       - name: Run AI Commit Script
         env:
@@ -44,8 +52,16 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-ci.txt
 
       - name: Run AI Pull Request Script
         env:
@@ -65,8 +81,16 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-ci.txt
 
       - name: Run AI Issue Handler
         env:
@@ -86,8 +110,16 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install dependencies
-        run: pip install -r requirements.txt
+        run: pip install -r requirements-ci.txt
 
       - name: Run AI Auto-Merge
         env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -24,10 +24,18 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-ci.txt
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
-          ref: main
 
       - name: Set Up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,10 +29,18 @@ jobs:
         with:
           python-version: "3.9"
 
+      - name: Cache pip
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements-ci.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
       - name: 📦 Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-ci.txt
 
       - name: 🚀 Run Tests
         run: pytest --disable-warnings || echo "⚠️ Tests failed, but continuing deployment..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v4
-        with:
-          ref: main
 
       - name: 🔐 Authenticate with GitHub
         env:

--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.GH_PAT }}
-          ref: main
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$PYTHONPATH:$(pwd)" >> $GITHUB_ENV

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+pydantic
+pydantic-settings
+prometheus-client
+psutil
+pytest
+httpx


### PR DESCRIPTION
## Summary
- add a minimal `requirements-ci.txt` for automation and testing
- switch workflows to install from the lighter requirements file
- cache Python dependencies to speed up CI runs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcf42016bc8333b266297f74f51a5a