### PR TITLE
Pin numpy and scipy dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,11 +14,11 @@ jax>=0.4.20
 jaxlib>=0.4.20
 
 # HFCTM-II specific
-numpy>=1.24,<2
-scipy>=1.11,<1.13
-pywavelets>=1.4.1
-networkx>=3.1
 cryptography>=41.0.0
+networkx>=3.1
+numpy>=1.24,<2
+pywavelets>=1.4.1
+scipy>=1.11,<1.13
 
 # Existing ORION
 fastapi>=0.104.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ jax>=0.4.20
 jaxlib>=0.4.20
 
 # HFCTM-II specific
-numpy>=1.24.0
-scipy>=1.11.0
+numpy>=1.24,<2
+scipy>=1.11,<1.13
 pywavelets>=1.4.1
 networkx>=3.1
 cryptography>=41.0.0


### PR DESCRIPTION
## Summary
- narrow numpy dependency to <2
- restrict scipy to <1.13 for compatibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd01048e2c8333b038e4dfb2b4450e