### PR TITLE
Handle missing requests dependency

### DIFF
--- a/telemetry/transports.py
+++ b/telemetry/transports.py
@@ -6,7 +6,10 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import requests
+try:  # pragma: no cover - optional dependency
+    import requests
+except Exception:  # pragma: no cover - import may fail
+    requests = None  # type: ignore
 
 
 class TransportProtocol:
@@ -37,7 +40,9 @@ class FileTransport(TransportProtocol):
 class HTTPTransport(TransportProtocol):
     """POST telemetry records to an HTTP endpoint."""
 
-    def __init__(self, url: str, *, session: Optional[requests.Session] = None) -> None:
+    def __init__(self, url: str, *, session: Optional["requests.Session"] = None) -> None:
+        if requests is None:
+            raise RuntimeError("requests library is required for HTTPTransport")
         self.url = url
         self.session = session or requests.Session()
 


### PR DESCRIPTION
## Summary
- gracefully handle missing `requests` dependency for HTTP telemetry transport

## Testing
- `JAX_PLATFORM_NAME=cpu python -m pytest` *(fails: Backend 'tpu' failed to initialize: libtpu.so missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bd019fc9fc83338e2d26f40d0116c8