### PR TITLE
Pin networkx dependency below 3.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jaxlib>=0.4.20,<0.5.0
 numpy>=1.24.0,<2.1.0
 scipy>=1.11.0,<1.13.0
 pywavelets>=1.4.1,<1.5.0
-networkx>=3.1,<3.2.0
+networkx>=3.1,<3.2.0  # pinned below 3.2.0
 cryptography>=41.0.0,<42.0.0
 
 # Existing ORION


### PR DESCRIPTION
## Summary
- document networkx requirement with upper bound below 3.2.0

## Testing
- `pip install --dry-run -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68bd0f56369083338d48d3b22e331b2e