### PR TITLE
Pin httpx to 0.27.0 and remove unused deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ jaxlib>=0.4.20,<0.5.0
 
 # HFCTM-II specific
 numpy>=1.24.0,<2.1.0
-scipy>=1.11.0,<1.13.0
 pywavelets>=1.4.1,<1.5.0
 networkx>=3.1,<3.2.0
 cryptography>=41.0.0,<42.0.0
@@ -25,7 +24,6 @@ fastapi>=0.104.0,<0.105.0
 uvicorn>=0.24.0,<0.25.0
 pydantic>=2.5.0,<2.6.0
 pydantic-settings>=2.1.0,<2.2.0
-prometheus-client>=0.19.0,<0.20.0
 psutil>=5.9.0,<5.10.0
 pytest>=8.0.0,<8.1.0
-httpx>=0.27.0,<0.28.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- pin httpx to 0.27.0 for TestClient compatibility
- remove unused scipy and prometheus-client requirements

## Testing
- `pip install -r requirements.txt` *(fails: dependency resolution took too long and was interrupted)*
- `pip install httpx==0.27.0`
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi' and others)*

------
https://chatgpt.com/codex/tasks/task_e_68bdbdb820588333b2d32636dd9a0303