### PR TITLE
Relax quantum dependency pins to resolve CI conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ uvicorn[standard]>=0.20.0
 pydantic>=2.5.0
 numpy>=1.24.0
 pyyaml>=6.0
+cirq>=1.1.0
+cirq-rigetti>=0.15.0
+networkx>=3.1


### PR DESCRIPTION
## Summary
- loosen cirq/cirq-rigetti/networkx versions to avoid dependency resolution failures

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdcdcb19b083339c92a6a487a029b4