### PR TITLE
fix: pin networkx for pyquil compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jaxlib>=0.4.20,<0.5.0
 numpy>=1.24.0,<2.1.0
 scipy>=1.11.0,<1.13.0
 pywavelets>=1.4.1,<1.5.0
-networkx>=3.1,<3.2.0
+networkx>=2.8,<3.0
 cryptography>=41.0.0,<42.0.0
 
 # Existing ORION


### PR DESCRIPTION
## Summary
- revert extraneous requirement formatting and pin networkx to <3 for pyquil compatibility

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68bddef1ecb88333aac10b453eac9035