### PR TITLE
feat: add recursive depth metrics

### DIFF
--- a/orion_api/routers/manifold_router.py
+++ b/orion_api/routers/manifold_router.py
@@ -1,9 +1,35 @@
+"""Manifold router for distributing tasks with depth metrics."""
+
 from fastapi import APIRouter
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client import Histogram
+except Exception:  # pragma: no cover - optional dependency
+    class Histogram:  # type: ignore[misc]
+        """No-op fallback when prometheus_client is unavailable."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            pass
+
+        def observe(self, value: float) -> None:
+            return None
+
+    logger.info("prometheus_client not installed; manifold depth metrics disabled")
+
+manifold_depth_metric = Histogram(
+    "orion_manifold_depth",
+    "Recursive depth used when distributing tasks",
+)
 
 router = APIRouter()
 
+
 @router.post("/distribute_task")
-async def distribute_task(task: str, depth: int):
-    """Distribute tasks among recursive agents."""
+async def distribute_task(task: str, depth: int) -> dict:
+    """Distribute tasks among recursive agents and record depth."""
+    manifold_depth_metric.observe(depth)
     return {"message": f"Task '{task}' distributed with recursion depth {depth}."}
 

--- a/orion_api/routers/recursive_ai.py
+++ b/orion_api/routers/recursive_ai.py
@@ -1,15 +1,45 @@
+"""Recursive AI router with depth metric instrumentation."""
+
 from fastapi import APIRouter
 from pydantic import BaseModel
 from models.recursive_ai_model import recursive_model_live
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:
+    from prometheus_client import Histogram
+except Exception:  # pragma: no cover - optional dependency
+    class Histogram:  # type: ignore[misc]
+        """No-op fallback when prometheus_client is unavailable."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            pass
+
+        def observe(self, value: float) -> None:
+            return None
+
+    logger.info("prometheus_client not installed; recursive depth metrics disabled")
+
+recursive_depth_metric = Histogram(
+    "orion_recursive_ai_depth",
+    "Depth of recursion requested for the recursive AI endpoint",
+)
 
 router = APIRouter()
 
+
 class RecursiveRequest(BaseModel):
+    """Request model for recursive inference calls."""
+
     query: str
     depth: int = 1
 
+
 @router.post("/infer")
-async def recursive_infer(request: RecursiveRequest):
+async def recursive_infer(request: RecursiveRequest) -> dict:
+    """Perform recursive inference and track recursion depth."""
+    recursive_depth_metric.observe(request.depth)
     response = recursive_model_live(request.query, request.depth)
     return {"response": response, "depth": request.depth}
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,33 @@
+"""Tests for Prometheus metrics on recursive endpoints."""
+
+from fastapi.testclient import TestClient
+import pytest
+
+pytest.importorskip("prometheus_client")
+pytest.importorskip("torch")
+
+from orion_api.main import app
+
+
+client = TestClient(app)
+
+
+def test_recursive_ai_depth_metric() -> None:
+    """Ensure recursive AI endpoint records depth metric."""
+    response = client.post(
+        "/api/v1/recursive_ai/infer", json={"query": "test", "depth": 2}
+    )
+    assert response.status_code == 200
+    metrics_resp = client.get("/metrics")
+    assert "orion_recursive_ai_depth_sum" in metrics_resp.text
+
+
+def test_manifold_depth_metric() -> None:
+    """Ensure manifold router records recursion depth metric."""
+    response = client.post(
+        "/manifold/distribute_task", params={"task": "t", "depth": 3}
+    )
+    assert response.status_code == 200
+    metrics_resp = client.get("/metrics")
+    assert "orion_manifold_depth_sum" in metrics_resp.text
+


### PR DESCRIPTION
## Summary
- track recursion depth in recursive API endpoints using Prometheus histograms
- add tests verifying recursive depth metrics exposure

## Testing
- `python -m pytest --disable-warnings --maxfail=1 -q`


------
https://chatgpt.com/codex/tasks/task_e_68be384075008333a998aa197287d8fb