### PR TITLE
Handle optional torch dependency in API

### DIFF
--- a/orion_api/hfctm_safety.py
+++ b/orion_api/hfctm_safety.py
@@ -2,10 +2,24 @@
 
 import asyncio
 import numpy as np
-import torch
 from typing import Dict, List, Optional
 from dataclasses import dataclass
 import logging
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+    TORCH_AVAILABLE = True
+except Exception:  # pragma: no cover - import error handling
+    TORCH_AVAILABLE = False
+
+    class _TorchStub:
+        class Tensor:  # pragma: no cover - type stub
+            pass
+
+        def __getattr__(self, name):  # pragma: no cover - defensive
+            raise RuntimeError("PyTorch is not installed")
+
+    torch = _TorchStub()  # type: ignore
 
 # Hardware availability checks
 try:

--- a/orion_api/orion_api.py
+++ b/orion_api/orion_api.py
@@ -1,9 +1,20 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 import uvicorn
-import torch
 import numpy as np
 from orion_api.config import settings
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+    TORCH_AVAILABLE = True
+except Exception:  # pragma: no cover - import error handling
+    TORCH_AVAILABLE = False
+
+    class _TorchStub:
+        def __getattr__(self, name):  # pragma: no cover - defensive
+            raise RuntimeError("PyTorch is not installed")
+
+    torch = _TorchStub()  # type: ignore
 
 app = FastAPI(title="O.R.I.O.N. ∞ API", version="1.0")
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,4 @@
 from fastapi.testclient import TestClient
-import pytest
-
-torch = pytest.importorskip("torch")
 from orion_api.main import app
 
 client = TestClient(app)

--- a/tests/test_safety_status.py
+++ b/tests/test_safety_status.py
@@ -1,0 +1,39 @@
+import importlib
+from fastapi.testclient import TestClient
+import orion_api.main as main
+
+
+def test_safety_status_without_torch():
+    importlib.reload(main)
+    client = TestClient(main.app)
+    response = client.get("/api/safety/status")
+    assert response.status_code == 200
+    assert response.json()["error"].lower().startswith("pytorch not installed")
+
+
+def test_safety_status_with_stubbed_torch(monkeypatch):
+    importlib.reload(main)
+    client = TestClient(main.app)
+
+    class TorchStub:
+        def randn(self, *shape):
+            return [[0] * (shape[1] if len(shape) > 1 else 1) for _ in range(shape[0] if shape else 1)]
+
+    monkeypatch.setattr(main, "TORCH_AVAILABLE", True)
+    monkeypatch.setattr(main, "torch", TorchStub())
+
+    class SafetyCoreStub:
+        intervention_count = 1
+
+        async def safety_check(self, state):  # pragma: no cover - simple stub
+            return {"safe": True}
+
+    monkeypatch.setattr(main, "safety_core", SafetyCoreStub())
+
+    response = client.get("/api/safety/status")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["safety_active"] is True
+    assert data["interventions_total"] == 1
+    assert data["last_check"] == {"safe": True}
+


### PR DESCRIPTION
## Summary
- wrap torch imports with fallback stubs and availability flags
- guard recursive router inclusion and safety_status when torch is missing
- add tests for safety endpoint and enable API tests without torch

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68be3daf0e048333b4c46794d51047fb