### PR TITLE
refactor: centralize prometheus histogram wrapper

### DIFF
--- a/orion_api/routers/manifold_router.py
+++ b/orion_api/routers/manifold_router.py
@@ -1,23 +1,8 @@
 """Manifold router for distributing tasks with depth metrics."""
 
 from fastapi import APIRouter
-import logging
 
-logger = logging.getLogger(__name__)
-
-try:
-    from prometheus_client import Histogram
-except Exception:  # pragma: no cover - optional dependency
-    class Histogram:  # type: ignore[misc]
-        """No-op fallback when prometheus_client is unavailable."""
-
-        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
-            pass
-
-        def observe(self, value: float) -> None:
-            return None
-
-    logger.info("prometheus_client not installed; manifold depth metrics disabled")
+from orion_api.telemetry.prometheus import Histogram
 
 manifold_depth_metric = Histogram(
     "orion_manifold_depth",

--- a/orion_api/routers/recursive_ai.py
+++ b/orion_api/routers/recursive_ai.py
@@ -3,23 +3,8 @@
 from fastapi import APIRouter
 from pydantic import BaseModel
 from models.recursive_ai_model import recursive_model_live
-import logging
 
-logger = logging.getLogger(__name__)
-
-try:
-    from prometheus_client import Histogram
-except Exception:  # pragma: no cover - optional dependency
-    class Histogram:  # type: ignore[misc]
-        """No-op fallback when prometheus_client is unavailable."""
-
-        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
-            pass
-
-        def observe(self, value: float) -> None:
-            return None
-
-    logger.info("prometheus_client not installed; recursive depth metrics disabled")
+from orion_api.telemetry.prometheus import Histogram
 
 recursive_depth_metric = Histogram(
     "orion_recursive_ai_depth",

--- a/orion_api/telemetry/prometheus.py
+++ b/orion_api/telemetry/prometheus.py
@@ -1,0 +1,28 @@
+"""Prometheus metric helpers with graceful fallbacks.
+
+This module exposes thin wrappers around prometheus_client metrics that
+handle the optional dependency gracefully. When prometheus_client is not
+available, the provided classes become no-op implementations so that the
+rest of the application can continue to operate without instrumentation.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+try:  # pragma: no cover - optional dependency
+    from prometheus_client import Histogram as _Histogram
+    Histogram = _Histogram
+except Exception:  # pragma: no cover - import error
+    class Histogram:  # type: ignore[misc]
+        """No-op fallback when prometheus_client is unavailable."""
+
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401
+            pass
+
+        def observe(self, value: float) -> None:
+            return None
+
+    logger.info("prometheus_client not installed; metrics disabled")

--- a/tests/test_metrics_no_prometheus.py
+++ b/tests/test_metrics_no_prometheus.py
@@ -12,9 +12,10 @@ from fastapi import APIRouter
 
 def test_metrics_without_prometheus(monkeypatch):
     """The /metrics endpoint should handle missing prometheus_client."""
-    # Ensure prometheus_client and main module are re-imported
+    # Ensure prometheus_client and relevant modules are re-imported
     monkeypatch.delitem(sys.modules, "prometheus_client", raising=False)
     monkeypatch.delitem(sys.modules, "orion_api.main", raising=False)
+    monkeypatch.delitem(sys.modules, "orion_api.telemetry.prometheus", raising=False)
 
     # Provide dummy modules to avoid heavy dependencies
     dummy_pkg = types.ModuleType("orion_api")


### PR DESCRIPTION
## Summary
- add telemetry.prometheus utility wrapping Prometheus Histogram with graceful fallback
- use shared Histogram wrapper in manifold and recursive_ai routers
- adjust metrics tests to reload wrapper when prometheus_client missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be4647419883339ac4fb238f091484