### PR TITLE
feat(arch): Add AUR-style packaging (PKGBUILD), systemd unit, and CLI launcher

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,58 @@
+# Maintainer: Joshua-friendly recipe via ChatGPT
+pkgname=hfctm-ii-orion-git
+pkgver=0
+pkgrel=1
+pkgdesc="Omniversal Recursive Intelligence for Ontological Navigation (HFCTM-II-ORION)"
+arch=('x86_64')
+url='https://github.com/Grimmasura/HFCTM-II-ORION'
+license=('GPL2')
+depends=(
+  'python'
+  'python-fastapi'
+  'python-uvicorn'
+  'python-numpy'
+  'python-pydantic'
+  'python-httpx'
+  'python-psutil'
+)
+optdepends=(
+  'python-scipy: quantum stabilizer & ODE solvers'
+  'python-scikit-learn: metrics and validation utilities'
+  'python-torch: deep learning backends'
+  'python-prometheus-client: /metrics endpoint'
+)
+makedepends=('git')
+source=("git+${url}.git")
+md5sums=('SKIP')
+
+pkgver() {
+  cd "${srcdir}/HFCTM-II-ORION"
+  echo "r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
+}
+
+build() {
+  cd "${srcdir}/HFCTM-II-ORION"
+  # nothing to build; python project without pyproject
+  :
+}
+
+package() {
+  install -d "${pkgdir}/opt/hfctm-ii-orion"
+  cp -a "${srcdir}/HFCTM-II-ORION"/. "${pkgdir}/opt/hfctm-ii-orion/"
+
+  # wrapper
+  install -d "${pkgdir}/usr/bin"
+  install -m755 "${srcdir}/orion-api" "${pkgdir}/usr/bin/orion-api"
+
+  # systemd unit
+  install -d "${pkgdir}/usr/lib/systemd/system"
+  install -m644 "${srcdir}/orion-api.service" "${pkgdir}/usr/lib/systemd/system/orion-api.service"
+
+  # optional env dir
+  install -d "${pkgdir}/etc/orion"
+  install -m644 "${srcdir}/orion.env.example" "${pkgdir}/etc/orion/orion.env"
+
+  # docs
+  install -d "${pkgdir}/usr/share/doc/${pkgname}"
+  install -m644 "${srcdir}/README-arch.md" "${pkgdir}/usr/share/doc/${pkgname}/README-arch.md"
+}

--- a/README-arch.md
+++ b/README-arch.md
@@ -1,0 +1,26 @@
+# Arch packaging for HFCTM-II-ORION
+
+## Quick start (AUR-style build)
+```bash
+sudo pacman -S --needed base-devel git
+git clone https://github.com/Grimmasura/HFCTM-II-ORION.git
+cd HFCTM-II-ORION
+makepkg -si
+```
+
+## Run
+```bash
+sudo systemctl enable --now orion-api.service
+# or run manually
+ORION_PORT=8080 orion-api
+```
+
+## Where things go
+- Code: `/opt/hfctm-ii-orion`
+- Launcher: `/usr/bin/orion-api`
+- Service: `/usr/lib/systemd/system/orion-api.service`
+- Optional env: `/etc/orion/orion.env`
+
+## Dependencies
+- Required: `python`, `python-fastapi`, `python-uvicorn`, `python-numpy`, `python-pydantic`, `python-httpx`, `python-psutil`
+- Optional: `python-scipy`, `python-scikit-learn`, `python-torch`, `python-prometheus-client`

--- a/README.md
+++ b/README.md
@@ -103,3 +103,16 @@ most deployments this means providing the standard service principal secrets:
 Scripts such as `commit_file.py` can automatically commit changes. To push to a
 remote repository these scripts require a `GITHUB_TOKEN` environment variable.
 Without the token they will create the commit locally and skip the push step.
+
+## Arch Linux (AUR-style)
+
+Arch users can build and install from the repo root:
+
+```bash
+sudo pacman -S --needed base-devel git
+git clone https://github.com/Grimmasura/HFCTM-II-ORION.git
+cd HFCTM-II-ORION
+makepkg -si
+```
+
+See `README-arch.md` for details, systemd usage, and optional dependencies.

--- a/orion-api
+++ b/orion-api
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Simple launcher for the ORION FastAPI app
+export PYTHONPATH="/opt/hfctm-ii-orion:${PYTHONPATH}"
+HOST="${ORION_HOST:-0.0.0.0}"
+PORT="${ORION_PORT:-8000}"
+exec uvicorn orion_api:app --host "${HOST}" --port "${PORT}"

--- a/orion-api.service
+++ b/orion-api.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=HFCTM-II-ORION API Service
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=PYTHONPATH=/opt/hfctm-ii-orion
+WorkingDirectory=/opt/hfctm-ii-orion
+ExecStart=/usr/bin/orion-api
+Restart=on-failure
+# Uncomment if you add a dedicated service account:
+# User=orion
+# Group=orion
+
+[Install]
+WantedBy=multi-user.target

--- a/orion.env.example
+++ b/orion.env.example
@@ -1,0 +1,5 @@
+# Example environment overrides for ORION
+# ORION_HOST=127.0.0.1
+# ORION_PORT=8000
+# ORION_MODEL_DIR=/var/lib/orion/models
+# ORION_LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- add AUR-style PKGBUILD for `makepkg -si` installs
- include `orion-api` launcher and `orion-api.service` unit
- document Arch packaging in `README-arch.md` and main README

## Testing
- `shellcheck orion-api` *(fails: command not found)*
- `systemd-analyze verify orion-api.service`
- `namcap PKGBUILD` *(fails: command not found)*
- `makepkg -si --noconfirm` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4c1ecfe74833382902d28b0ec9d69