### PR TITLE
feat(arch): AUR-style packaging with correct deps, sources, and service

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,10 +6,11 @@ pkgdesc="Omniversal Recursive Intelligence for Ontological Navigation (HFCTM-II-
 arch=('x86_64')
 url='https://github.com/Grimmasura/HFCTM-II-ORION'
 license=('GPL2')
+
 depends=(
   'python'
   'python-fastapi'
-  'uvicorn'
+  'uvicorn'           # Arch package name (NOT python-uvicorn)
   'python-numpy'
   'python-pydantic'
   'python-httpx'
@@ -22,37 +23,48 @@ optdepends=(
   'python-prometheus-client: /metrics endpoint'
 )
 makedepends=('git')
-source=("git+${url}.git")
-md5sums=('SKIP')
+
+# Include auxiliary files so they exist in ${srcdir} at package() time
+source=(
+  "git+${url}.git"
+  "orion-api"
+  "orion-api.service"
+  "README-arch.md"
+  "orion.env.example"
+)
+sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
 
 pkgver() {
   cd "${srcdir}/HFCTM-II-ORION"
   echo "r$(git rev-list --count HEAD).$(git rev-parse --short HEAD)"
 }
 
+prepare() {
+  chmod +x "${srcdir}/orion-api"
+}
+
 build() {
-  cd "${srcdir}/HFCTM-II-ORION"
-  # nothing to build; python project without pyproject
-  :
+  : # nothing to build; python project without pyproject
 }
 
 package() {
+  # Code payload
   install -d "${pkgdir}/opt/hfctm-ii-orion"
   cp -a "${srcdir}/HFCTM-II-ORION"/. "${pkgdir}/opt/hfctm-ii-orion/"
 
-  # wrapper
-  install -d "${pkgdir}/usr/bin"
-  install -m755 "${srcdir}/orion-api" "${pkgdir}/usr/bin/orion-api"
+  # CLI wrapper
+  install -Dm755 "${srcdir}/orion-api" \
+    "${pkgdir}/usr/bin/orion-api"
 
   # systemd unit
-  install -d "${pkgdir}/usr/lib/systemd/system"
-  install -m644 "${srcdir}/orion-api.service" "${pkgdir}/usr/lib/systemd/system/orion-api.service"
+  install -Dm644 "${srcdir}/orion-api.service" \
+    "${pkgdir}/usr/lib/systemd/system/orion-api.service"
 
-  # optional env dir
-  install -d "${pkgdir}/etc/orion"
-  install -m644 "${srcdir}/orion.env.example" "${pkgdir}/etc/orion/orion.env"
+  # env example
+  install -Dm644 "${srcdir}/orion.env.example" \
+    "${pkgdir}/etc/orion/orion.env"
 
   # docs
-  install -d "${pkgdir}/usr/share/doc/${pkgname}"
-  install -m644 "${srcdir}/README-arch.md" "${pkgdir}/usr/share/doc/${pkgname}/README-arch.md"
+  install -Dm644 "${srcdir}/README-arch.md" \
+    "${pkgdir}/usr/share/doc/${pkgname}/README-arch.md"
 }

--- a/README-arch.md
+++ b/README-arch.md
@@ -1,26 +1,18 @@
 # Arch packaging for HFCTM-II-ORION
 
-## Quick start (AUR-style build)
-```bash
+## Quick start
 sudo pacman -S --needed base-devel git
 git clone https://github.com/Grimmasura/HFCTM-II-ORION.git
 cd HFCTM-II-ORION
 makepkg -si
-```
 
 ## Run
-```bash
 sudo systemctl enable --now orion-api.service
-# or run manually
+# or:
 ORION_PORT=8080 orion-api
-```
 
-## Where things go
-- Code: `/opt/hfctm-ii-orion`
-- Launcher: `/usr/bin/orion-api`
-- Service: `/usr/lib/systemd/system/orion-api.service`
-- Optional env: `/etc/orion/orion.env`
-
-## Dependencies
-- Required: `python`, `python-fastapi`, `python-uvicorn`, `python-numpy`, `python-pydantic`, `python-httpx`, `python-psutil`
-- Optional: `python-scipy`, `python-scikit-learn`, `python-torch`, `python-prometheus-client`
+## Paths
+- Code: /opt/hfctm-ii-orion
+- CLI: /usr/bin/orion-api
+- Service: /usr/lib/systemd/system/orion-api.service
+- Env: /etc/orion/orion.env

--- a/README.md
+++ b/README.md
@@ -106,8 +106,6 @@ Without the token they will create the commit locally and skip the push step.
 
 ## Arch Linux (AUR-style)
 
-Arch users can build and install from the repo root:
-
 ```bash
 sudo pacman -S --needed base-devel git
 git clone https://github.com/Grimmasura/HFCTM-II-ORION.git
@@ -115,4 +113,4 @@ cd HFCTM-II-ORION
 makepkg -si
 ```
 
-See `README-arch.md` for details, systemd usage, and optional dependencies.
+See `README-arch.md` for systemd usage and optional dependencies.

--- a/orion-api.service
+++ b/orion-api.service
@@ -9,7 +9,6 @@ Environment=PYTHONPATH=/opt/hfctm-ii-orion
 WorkingDirectory=/opt/hfctm-ii-orion
 ExecStart=/usr/bin/orion-api
 Restart=on-failure
-# Uncomment if you add a dedicated service account:
 # User=orion
 # Group=orion
 

--- a/orion.env.example
+++ b/orion.env.example
@@ -1,4 +1,4 @@
-# Example environment overrides for ORION
+# Example environment for ORION
 # ORION_HOST=127.0.0.1
 # ORION_PORT=8000
 # ORION_MODEL_DIR=/var/lib/orion/models


### PR DESCRIPTION
## Summary
- Replace Arch `PKGBUILD` with full AUR-style recipe, listing proper dependencies and including auxiliary files in `source()`.
- Ship CLI wrapper, systemd unit, and environment example for `/opt`-based installs.
- Document Arch installation process in dedicated `README-arch.md` and main `README.md`.

## Testing
- `sudo pacman -S --needed base-devel git namcap` *(fails: pacman not found)*
- `namcap PKGBUILD` *(fails: command not found)*
- `makepkg -si --noconfirm` *(fails: command not found)*
- `systemctl status orion-api.service --no-pager` *(fails: systemd not active)*
- `uvicorn --version`
- `curl -s http://127.0.0.1:8000/ | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_68c4c865ee5c8333b714933bdba1093b