### PR TITLE
fix(arch): stable ASGI entrypoint + repo-embedded Arch packaging

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Joshua-friendly recipe via ChatGPT
 pkgname=hfctm-ii-orion-git
 pkgver=0
-pkgrel=1
+pkgrel=2
 pkgdesc="Omniversal Recursive Intelligence for Ontological Navigation (HFCTM-II-ORION)"
 arch=('x86_64')
 url='https://github.com/Grimmasura/HFCTM-II-ORION'
@@ -24,15 +24,8 @@ optdepends=(
 )
 makedepends=('git')
 
-# Include auxiliary files so they exist in ${srcdir} at package() time
-source=(
-  "git+${url}.git"
-  "orion-api"
-  "orion-api.service"
-  "README-arch.md"
-  "orion.env.example"
-)
-sha256sums=('SKIP' 'SKIP' 'SKIP' 'SKIP' 'SKIP')
+source=("git+${url}.git")
+sha256sums=('SKIP')
 
 pkgver() {
   cd "${srcdir}/HFCTM-II-ORION"
@@ -40,7 +33,8 @@ pkgver() {
 }
 
 prepare() {
-  chmod +x "${srcdir}/orion-api"
+  cd "${srcdir}/HFCTM-II-ORION"
+  chmod +x packaging/arch/orion-api
 }
 
 build() {
@@ -48,23 +42,25 @@ build() {
 }
 
 package() {
+  cd "${srcdir}/HFCTM-II-ORION"
+
   # Code payload
   install -d "${pkgdir}/opt/hfctm-ii-orion"
-  cp -a "${srcdir}/HFCTM-II-ORION"/. "${pkgdir}/opt/hfctm-ii-orion/"
+  cp -a . "${pkgdir}/opt/hfctm-ii-orion/"
 
   # CLI wrapper
-  install -Dm755 "${srcdir}/orion-api" \
+  install -Dm755 "packaging/arch/orion-api" \
     "${pkgdir}/usr/bin/orion-api"
 
   # systemd unit
-  install -Dm644 "${srcdir}/orion-api.service" \
+  install -Dm644 "packaging/arch/orion-api.service" \
     "${pkgdir}/usr/lib/systemd/system/orion-api.service"
 
   # env example
-  install -Dm644 "${srcdir}/orion.env.example" \
+  install -Dm644 "packaging/arch/orion.env.example" \
     "${pkgdir}/etc/orion/orion.env"
 
   # docs
-  install -Dm644 "${srcdir}/README-arch.md" \
+  install -Dm644 "packaging/arch/README-arch.md" \
     "${pkgdir}/usr/share/doc/${pkgname}/README-arch.md"
 }

--- a/README.md
+++ b/README.md
@@ -105,12 +105,4 @@ remote repository these scripts require a `GITHUB_TOKEN` environment variable.
 Without the token they will create the commit locally and skip the push step.
 
 ## Arch Linux (AUR-style)
-
-```bash
-sudo pacman -S --needed base-devel git
-git clone https://github.com/Grimmasura/HFCTM-II-ORION.git
-cd HFCTM-II-ORION
-makepkg -si
-```
-
-See `README-arch.md` for systemd usage and optional dependencies.
+See `packaging/arch/README-arch.md` for `makepkg -si`, systemd usage, and optional dependencies.

--- a/orion.env.example
+++ b/orion.env.example
@@ -1,5 +1,0 @@
-# Example environment for ORION
-# ORION_HOST=127.0.0.1
-# ORION_PORT=8000
-# ORION_MODEL_DIR=/var/lib/orion/models
-# ORION_LOG_LEVEL=info

--- a/orion_asgi.py
+++ b/orion_asgi.py
@@ -1,0 +1,6 @@
+"""
+ASGI adapter for HFCTM-II-ORION.
+Exports a top-level `app` for Uvicorn by building it via the enhanced factory.
+"""
+from orion_enhanced_extensions import create_enhanced_orion_api
+app = create_enhanced_orion_api()

--- a/packaging/arch/README-arch.md
+++ b/packaging/arch/README-arch.md
@@ -8,7 +8,7 @@ makepkg -si
 
 ## Run
 sudo systemctl enable --now orion-api.service
-# or:
+# or run directly:
 ORION_PORT=8080 orion-api
 
 ## Paths
@@ -16,3 +16,7 @@ ORION_PORT=8080 orion-api
 - CLI: /usr/bin/orion-api
 - Service: /usr/lib/systemd/system/orion-api.service
 - Env: /etc/orion/orion.env
+
+## Optional deps
+sudo pacman -S python-scipy python-scikit-learn python-prometheus-client
+# DL backend (optional): python-pytorch or python-pytorch-cuda

--- a/packaging/arch/orion-api
+++ b/packaging/arch/orion-api
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Simple launcher for the ORION FastAPI app
+# ORION FastAPI launcher
 export PYTHONPATH="/opt/hfctm-ii-orion:${PYTHONPATH}"
 HOST="${ORION_HOST:-0.0.0.0}"
 PORT="${ORION_PORT:-8000}"
-exec uvicorn orion_api:app --host "${HOST}" --port "${PORT}"
+exec uvicorn orion_asgi:app --host "${HOST}" --port "${PORT}"

--- a/packaging/arch/orion-api.service
+++ b/packaging/arch/orion-api.service
@@ -5,12 +5,11 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+EnvironmentFile=/etc/orion/orion.env
 Environment=PYTHONPATH=/opt/hfctm-ii-orion
 WorkingDirectory=/opt/hfctm-ii-orion
 ExecStart=/usr/bin/orion-api
 Restart=on-failure
-# User=orion
-# Group=orion
 
 [Install]
 WantedBy=multi-user.target

--- a/packaging/arch/orion.env.example
+++ b/packaging/arch/orion.env.example
@@ -1,0 +1,5 @@
+# ORION environment (read by systemd unit via EnvironmentFile)
+# ORION_HOST=0.0.0.0
+# ORION_PORT=8000
+# ORION_MODEL_DIR=/var/lib/orion/models
+# ORION_LOG_LEVEL=info


### PR DESCRIPTION
## Summary
- add `orion_asgi.py` adapter exposing `app`
- embed Arch packaging assets under `packaging/arch`
- rewrite PKGBUILD to install from repo content and point README to packaging docs

## Testing
- `pytest -q`
- `makepkg -si --noconfirm` *(fails: command not found)*
- `systemctl status orion-api.service --no-pager` *(fails: System has not been booted with systemd as init system)*

------
https://chatgpt.com/codex/tasks/task_e_68c4cc5786348333abe0bf665afe5287