### PR TITLE
fix(arch): resilient ASGI entrypoint + repo-embedded packaging + tightened Arch deps

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Joshua-friendly recipe via ChatGPT
 pkgname=hfctm-ii-orion-git
 pkgver=0
-pkgrel=2
+pkgrel=3
 pkgdesc="Omniversal Recursive Intelligence for Ontological Navigation (HFCTM-II-ORION)"
 arch=('x86_64')
 url='https://github.com/Grimmasura/HFCTM-II-ORION'
@@ -10,17 +10,18 @@ license=('GPL2')
 depends=(
   'python'
   'python-fastapi'
-  'uvicorn'           # Arch package name (NOT python-uvicorn)
+  'uvicorn'
   'python-numpy'
   'python-pydantic'
   'python-httpx'
   'python-psutil'
+  'python-scipy'
+  'python-scikit-learn'
+  'python-prometheus-client'
 )
 optdepends=(
-  'python-scipy: quantum stabilizer & ODE solvers'
-  'python-scikit-learn: metrics and validation utilities'
-  'python-torch: deep learning backends'
-  'python-prometheus-client: /metrics endpoint'
+  'python-pytorch: deep learning backends (CPU)'
+  'python-pytorch-cuda: deep learning backends (CUDA)'
 )
 makedepends=('git')
 
@@ -38,7 +39,7 @@ prepare() {
 }
 
 build() {
-  : # nothing to build; python project without pyproject
+  :
 }
 
 package() {

--- a/orion_asgi.py
+++ b/orion_asgi.py
@@ -1,6 +1,26 @@
 """
 ASGI adapter for HFCTM-II-ORION.
-Exports a top-level `app` for Uvicorn by building it via the enhanced factory.
+- Tries to build the real FastAPI via create_enhanced_orion_api()
+- If it fails (missing deps, import error), exposes a fallback app with diagnostics
 """
-from orion_enhanced_extensions import create_enhanced_orion_api
-app = create_enhanced_orion_api()
+import logging
+
+try:
+    from orion_enhanced_extensions import create_enhanced_orion_api
+    app = create_enhanced_orion_api()
+except Exception as e:  # pragma: no cover - fallback path
+    logging.getLogger("uvicorn.error").exception("Failed to build ORION app", exc_info=e)
+    try:
+        from fastapi import FastAPI
+
+        app = FastAPI(title="ORION (fallback)")
+
+        @app.get("/healthz")
+        def healthz():
+            return {"status": "fallback", "error": str(e)}
+
+        @app.get("/")
+        def root():
+            return {"ok": True, "mode": "fallback"}
+    except Exception:  # pragma: no cover - if even FastAPI is missing
+        raise e

--- a/packaging/arch/README-arch.md
+++ b/packaging/arch/README-arch.md
@@ -18,5 +18,4 @@ ORION_PORT=8080 orion-api
 - Env: /etc/orion/orion.env
 
 ## Optional deps
-sudo pacman -S python-scipy python-scikit-learn python-prometheus-client
-# DL backend (optional): python-pytorch or python-pytorch-cuda
+sudo pacman -S python-pytorch  # or python-pytorch-cuda


### PR DESCRIPTION
## Summary
- add resilient ASGI entrypoint that falls back to diagnostic FastAPI app on import failure
- embed Arch packaging assets and update README instructions
- tighten Arch PKGBUILD runtime dependencies

## Testing
- `PYTHONPATH=. pytest -q` *(fails: assert 503 == 200)*

------
https://chatgpt.com/codex/tasks/task_e_68c4d1a292708333b281c6154bee6d78